### PR TITLE
The plugin must be always installed in CMS on devstack

### DIFF
--- a/extra_actions_post_devup.sh
+++ b/extra_actions_post_devup.sh
@@ -2,3 +2,5 @@
 # Some actions to perform after "make dev.up"
 echo "Installin llpa plugin on LMS"
 docker-compose exec lms bash -c "source /edx/app/edxapp/devstack.sh && cd /edx/src/llpa_openedx_extensions && pip install -e ."
+echo "Installin llpa plugin on CMS"
+docker-compose exec studio bash -c "source /edx/app/edxapp/devstack.sh && cd /edx/src/llpa_openedx_extensions && pip install -e ."


### PR DESCRIPTION
The plugin must be always installed in CMS on devstack since it's installed on CMS in production and we want to check there is no side effects on CMS functionality.

@cocococosti 
@morenol 